### PR TITLE
update: Add support for validating the codecommit-fips endpoint.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gembaadvantage/codecommit-sign
+module github.com/mkeener/codecommit-sign
 
 go 1.18
 

--- a/pkg/awsv4/signer.go
+++ b/pkg/awsv4/signer.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	urlRgx = regexp.MustCompile(`^https://git-codecommit\.(.*)\.(amazonaws\.com|amazonaws\.com\.cn)/v1/repos/.*$`)
+	urlRgx = regexp.MustCompile(`^https://(git-codecommit|git-codecommit-fips)\.(.*)\.(amazonaws\.com|amazonaws\.com\.cn)/v1/repos/.*$`)
 )
 
 // Signer implements the AWS authenticated V4 Signature Specification for

--- a/pkg/awsv4/signer.go
+++ b/pkg/awsv4/signer.go
@@ -38,6 +38,7 @@ import (
 )
 
 var (
+	// urlRgx = regexp.MustCompile(`^https://git-codecommit\.(.*)\.(amazonaws\.com|amazonaws\.com\.cn)/v1/repos/.*$`)
 	urlRgx = regexp.MustCompile(`^https://(git-codecommit|git-codecommit-fips)\.(.*)\.(amazonaws\.com|amazonaws\.com\.cn)/v1/repos/.*$`)
 )
 
@@ -92,7 +93,8 @@ func (s *Signer) Sign(cloneURL string) (string, error) {
 
 func identifyRegion(url string) (string, error) {
 	if m := urlRgx.FindStringSubmatch(url); len(m) > 1 {
-		return m[1], nil
+		// return m[2], errors.New(fmt.Sprintf("found submatch: %s", m[2]))
+		return m[2], nil
 	}
 
 	return "", errors.New("no region found in malformed codecommit URL")


### PR DESCRIPTION
Changing url regex to allow matching of git-codecommit or git-codecommit-fips endpoints. 